### PR TITLE
 Fixing Canvas Size for Ultra-Wide Screens (32:9 Aspect Ratio) 

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,7 +103,7 @@
     function Configure_FormantAnalyzer()
     {
         const BOX_HEIGHT = 300;
-        const BOX_WIDTH = window.screen.availWidth - 50; //reset the size of canvas element using the screen width
+        const BOX_WIDTH = window.innerWidth - 50; //reset the size of canvas element using the screen width
         document.getElementById('SpectrumCanvas').width = BOX_WIDTH;
         document.getElementById('SpectrumCanvas').height = BOX_HEIGHT;
         


### PR DESCRIPTION
During the testing on my local environment, which utilizes a 32:9 ultra-wide screen, it was noticed that the canvas was not sizing appropriately. It was extending to the full screen size even when the browser window was not maximized. This could potentially affect users with similar screen setups, offering a subpar user experience.

#### Changes 
This pull request addresses the issue by modifying the method of acquiring the screen width. Instead of using `window.screen.availWidth` which retrieves the total screen width, the change has been made to `window.innerWidth`. This ensures that the canvas sizes itself according to the actual inner width of the browser window.

Before: 
![CleanShot 2023-09-06 at 12 40 25](https://github.com/tabahi/formantanalyzer.js/assets/4542479/253311f7-9fbb-4414-bc62-55cc0578f906)

After:
![CleanShot 2023-09-06 at 12 41 02](https://github.com/tabahi/formantanalyzer.js/assets/4542479/588c00c0-35ad-4ffc-8e58-0a87120ac69c)

